### PR TITLE
Incorrect MaxTurnDurationInSeconds constant naming

### DIFF
--- a/x/checkers/types/full_game.go
+++ b/x/checkers/types/full_game.go
@@ -40,7 +40,7 @@ func (storedGame *StoredGame) GetDeadlineAsTime() (deadline time.Time, err error
 }
 
 func GetNextDeadline(ctx sdk.Context) time.Time {
-	return ctx.BlockTime().Add(MaxTurnDurationInSeconds)
+	return ctx.BlockTime().Add(MaxTurnDurationInNanoseconds)
 }
 
 func FormatDeadline(deadline time.Time) string {

--- a/x/checkers/types/keys.go
+++ b/x/checkers/types/keys.go
@@ -35,7 +35,7 @@ const (
 
 const (
 	NoFifoIdKey              = "-1"
-	MaxTurnDurationInSeconds = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
+	MaxTurnDurationInNanoseconds = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
 	DeadlineLayout           = "2006-01-02 15:04:05.999999999 +0000 UTC"
 )
 


### PR DESCRIPTION
To compute a game's deadline, we are giving it a default maximum duration of 24 hours, which is defined as:
```
 	MaxTurnDurationInSeconds = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
```

However, `24 * 3600 * 1e9` is a day in nanoseconds, I think we should rename:

`MaxTurnDurationInSeconds` to `MaxTurnDurationInNanoseconds`