### PR TITLE
Incorrect MaxTurnDurationInSeconds constant naming

### DIFF
--- a/x/checkers/keeper/msg_server_create_game_fifo_test.go
+++ b/x/checkers/keeper/msg_server_create_game_fifo_test.go
@@ -42,7 +42,7 @@ func TestCreate3GamesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "2",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 	game2, found2 := keeper.GetStoredGame(ctx, "2")
 	require.True(t, found2)
@@ -56,7 +56,7 @@ func TestCreate3GamesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game2)
 
 	msgSrvr.CreateGame(context, &types.MsgCreateGame{
@@ -84,7 +84,7 @@ func TestCreate3GamesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "2",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 	game2, found2 = keeper.GetStoredGame(ctx, "2")
 	require.True(t, found2)
@@ -98,7 +98,7 @@ func TestCreate3GamesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "1",
 		AfterId:   "3",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game2)
 	game3, found3 := keeper.GetStoredGame(ctx, "3")
 	require.True(t, found3)
@@ -112,6 +112,6 @@ func TestCreate3GamesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "2",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game3)
 }

--- a/x/checkers/keeper/msg_server_create_game_test.go
+++ b/x/checkers/keeper/msg_server_create_game_test.go
@@ -64,7 +64,7 @@ func TestCreate1GameHasSaved(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 }
 
@@ -88,7 +88,7 @@ func TestCreate1GameGetAll(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, games[0])
 }
 
@@ -208,7 +208,7 @@ func TestCreate3GamesHasSaved(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "2",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 	game2, found2 := keeper.GetStoredGame(ctx, "2")
 	require.True(t, found2)
@@ -222,7 +222,7 @@ func TestCreate3GamesHasSaved(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "1",
 		AfterId:   "3",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game2)
 	game3, found3 := keeper.GetStoredGame(ctx, "3")
 	require.True(t, found3)
@@ -236,7 +236,7 @@ func TestCreate3GamesHasSaved(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "2",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game3)
 }
 
@@ -270,7 +270,7 @@ func TestCreate3GamesGetAll(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "2",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, games[0])
 	require.EqualValues(t, types.StoredGame{
 		Creator:   bob,
@@ -282,7 +282,7 @@ func TestCreate3GamesGetAll(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "1",
 		AfterId:   "3",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, games[1])
 	require.EqualValues(t, types.StoredGame{
 		Creator:   carol,
@@ -294,6 +294,6 @@ func TestCreate3GamesGetAll(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "2",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, games[2])
 }

--- a/x/checkers/keeper/msg_server_play_move_fifo_test.go
+++ b/x/checkers/keeper/msg_server_play_move_fifo_test.go
@@ -45,7 +45,7 @@ func TestPlayMove2Games1MoveHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(1),
 		BeforeId:  "2",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 	game2, found2 := keeper.GetStoredGame(ctx, "2")
 	require.True(t, found2)
@@ -59,7 +59,7 @@ func TestPlayMove2Games1MoveHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(0),
 		BeforeId:  "-1",
 		AfterId:   "1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game2)
 }
 
@@ -108,7 +108,7 @@ func TestPlayMove2Games2MovesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(1),
 		BeforeId:  "-1",
 		AfterId:   "2",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 	game2, found2 := keeper.GetStoredGame(ctx, "2")
 	require.True(t, found2)
@@ -122,6 +122,6 @@ func TestPlayMove2Games2MovesHasSavedFifo(t *testing.T) {
 		MoveCount: uint64(1),
 		BeforeId:  "1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game2)
 }

--- a/x/checkers/keeper/msg_server_play_move_test.go
+++ b/x/checkers/keeper/msg_server_play_move_test.go
@@ -75,7 +75,7 @@ func TestPlayMoveSavedGame(t *testing.T) {
 		MoveCount: uint64(1),
 		BeforeId:  "-1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 }
 
@@ -200,7 +200,7 @@ func TestPlayMove2SavedGame(t *testing.T) {
 		MoveCount: uint64(2),
 		BeforeId:  "-1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 }
 
@@ -286,6 +286,6 @@ func TestPlayMove3SavedGame(t *testing.T) {
 		MoveCount: uint64(3),
 		BeforeId:  "-1",
 		AfterId:   "-1",
-		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDurationInSeconds)),
+		Deadline:  types.FormatDeadline(ctx.BlockTime().Add(types.MaxTurnDuration)),
 	}, game1)
 }

--- a/x/checkers/types/full_game.go
+++ b/x/checkers/types/full_game.go
@@ -43,7 +43,7 @@ func (storedGame *StoredGame) GetDeadlineAsTime() (deadline time.Time, err error
 }
 
 func GetNextDeadline(ctx sdk.Context) time.Time {
-	return ctx.BlockTime().Add(MaxTurnDurationInSeconds)
+	return ctx.BlockTime().Add(MaxTurnDuration)
 }
 
 func FormatDeadline(deadline time.Time) string {

--- a/x/checkers/types/keys.go
+++ b/x/checkers/types/keys.go
@@ -34,9 +34,9 @@ const (
 )
 
 const (
-	NoFifoIdKey              = "-1"
-	MaxTurnDurationInSeconds = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
-	DeadlineLayout           = "2006-01-02 15:04:05.999999999 +0000 UTC"
+	NoFifoIdKey				= "-1"
+	MaxTurnDuration			= time.Duration(24 * 3_600 * 1000_000_000) // 1 day
+	DeadlineLayout			= "2006-01-02 15:04:05.999999999 +0000 UTC"
 )
 
 const (

--- a/x/checkers/types/keys.go
+++ b/x/checkers/types/keys.go
@@ -34,9 +34,9 @@ const (
 )
 
 const (
-	NoFifoIdKey				= "-1"
-	MaxTurnDuration			= time.Duration(24 * 3_600 * 1000_000_000) // 1 day
-	DeadlineLayout			= "2006-01-02 15:04:05.999999999 +0000 UTC"
+	NoFifoIdKey     = "-1"
+	MaxTurnDuration = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
+	DeadlineLayout  = "2006-01-02 15:04:05.999999999 +0000 UTC"
 )
 
 const (


### PR DESCRIPTION
To compute a game's deadline, we are giving it a default maximum duration of 24 hours, which is defined as:
```
 	MaxTurnDurationInSeconds = time.Duration(24 * 3_600 * 1000_000_000) // 1 day
```

However, `24 * 3600 * 1e9` is a day in nanoseconds, I think we should rename:

`MaxTurnDurationInSeconds` to `MaxTurnDuration`

Since,
A) It's actually nanoseconds
B) Nanosecond unit is implied within the term `Duration`