### PR TITLE
Updated fmt.Errorf and "turn" string

### DIFF
--- a/x/checkers/types/full_game.go
+++ b/x/checkers/types/full_game.go
@@ -26,7 +26,7 @@ func (storedGame StoredGame) ParseGame() (game *rules.Game, err error) {
 	}
 	board.Turn = rules.StringPieces[storedGame.Turn].Player
 	if board.Turn.Color == "" {
-		return nil, sdkerrors.Wrapf(errors.New(fmt.Sprintf("Turn: %s", storedGame.Turn)), ErrGameNotParseable.Error())
+		return nil, sdkerrors.Wrapf(fmt.Errorf("turn: %s", storedGame.Turn), ErrGameNotParseable.Error())
 	}
 	return board, nil
 }


### PR DESCRIPTION
As suggested by go-staticcheck

1) should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (S1028) go-staticcheck 
2) error strings should not be capitalized (ST1005)go-staticcheck