### PR TITLE
Update msg_server_create_game_test.go

### DIFF
--- a/x/checkers/keeper/msg_server_create_game_test.go
+++ b/x/checkers/keeper/msg_server_create_game_test.go
@@ -224,6 +224,7 @@ func TestCreateGameFarFuture(t *testing.T) {
 	msgSrvr, keeper, context := setupMsgServerCreateGame(t)
 	ctx := sdk.UnwrapSDKContext(context)
 	systemInfo, found := keeper.GetSystemInfo(ctx)
+	require.True(t, found)
 	systemInfo.NextId = 1024
 	keeper.SetSystemInfo(ctx, systemInfo)
 	createResponse, err := msgSrvr.CreateGame(context, &types.MsgCreateGame{


### PR DESCRIPTION
Removed warning about unused variable from staticcheck "this value of found is never used (SA4006)"