### PR TITLE
Uncapitalize keyword `Turn` for full game tests to pass

### DIFF
--- a/x/checkers/types/full_game_test.go
+++ b/x/checkers/types/full_game_test.go
@@ -97,7 +97,7 @@ func TestParseGameWrongTurnColor(t *testing.T) {
 	storedGame.Turn = "w"
 	game, err := storedGame.ParseGame()
 	require.Nil(t, game)
-	require.EqualError(t, err, "game cannot be parsed: Turn: w")
+	require.EqualError(t, err, "game cannot be parsed: turn: w")
 	require.EqualError(t, storedGame.Validate(), err.Error())
 }
 


### PR DESCRIPTION
Small correction causing issue in tutorial page - https://tutorials.cosmos.network/hands-on-exercise/2-ignite-cli-adv/3-game-fifo.html


When running tests with 

```go
go test github.com/noslav/checkers/x/checkers/types
--- FAIL: TestParseGameWrongTurnColor (0.00s)
    full_game_test.go:99:
        	Error Trace:	/Users/pranay/Documents/covalent/covenet/cosmos/ignite-cli/checkers/x/checkers/types/full_game_test.go:99
        	Error:      	Error message not equal:
        	            	expected: "game cannot be parsed: Turn: w"
        	            	actual  : "game cannot be parsed: turn: w"
        	Test:       	TestParseGameWrongTurnColor
FAIL
FAIL	github.com/noslav/checkers/x/checkers/types	0.216s
FAIL
```

After fix

```
go test github.com/noslav/checkers/x/checkers/types
ok  	github.com/noslav/checkers/x/checkers/types	0.181s
```